### PR TITLE
Normalize command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ go.work
 
 ## Jetbrains IDE
 .idea
+
+## Custom Rules
+
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# virtual-kubelet-saladcloud
+
+.PHONY: build
+build: CGO_ENABLED=0
+build:
+	go build -o ./bin/virtual-kubelet ./cmd/virtual-kubelet/main.go
+
+.PHONY: clean
+clean:
+	rm -rf ./bin
+	go clean
+
+.PHONY: lint
+lint:
+	golangci-lint run ./... $(LINT_ARGS)
+
+.PHONY: test
+test:
+
+tidy:
+	go mod tidy

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ go mod download
 ```
 3. Build the project
 ```bash
-go build
+go build -o virtual-kubelet ./cmd/virtual-kubelet/main.go
 ```
 4. Run the project
 ```bash
-go run main.go --nodename {valid_node_name} --projectName {projectName} --organizationName {organizationName} --api-key {api-key} --kubeconfig {kubeconfig}
+go run main.go --nodename {valid_node_name} --sce-project-name {projectName} --sce-organization-name {organizationName} --sce-api-key {api-key} --kubeconfig {kubeconfig}
 ```
 
 ## Prerequisites

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -67,14 +67,15 @@ func main() {
 func initCommandFlags() {
 	virtualKubeletCommand.Flags().StringVar(&inputs.NodeName, "nodename", inputs.NodeName, "Kubernetes node name")
 	virtualKubeletCommand.Flags().StringVar(&inputs.KubeConfig, "kube-config", inputs.KubeConfig, "Kubeconfig file")
-	virtualKubeletCommand.Flags().StringVar(&inputs.OrganizationName, "organizationName", inputs.OrganizationName, "Organization name for Salad Client")
-	virtualKubeletCommand.Flags().BoolVar(&inputs.DisableTaint, "Disable taint flag", inputs.DisableTaint, "Disable the tainted effect")
-	virtualKubeletCommand.Flags().StringVar(&inputs.ApiKey, "api-key", inputs.ApiKey, "API key for the Salad Client")
-	virtualKubeletCommand.Flags().StringVar(&inputs.ProjectName, "projectName", inputs.ProjectName, "Project name for Salad Client")
-	virtualKubeletCommand.Flags().StringVar(&inputs.LogLevel, "logLevel", inputs.LogLevel, "Log level for the node, default to info")
+	virtualKubeletCommand.Flags().BoolVar(&inputs.DisableTaint, "disable-taint", inputs.DisableTaint, "Disable the tainted effect")
+	virtualKubeletCommand.Flags().StringVar(&inputs.LogLevel, "log-level", inputs.LogLevel, "Log level for the node")
+	virtualKubeletCommand.Flags().StringVar(&inputs.ApiKey, "sce-api-key", inputs.ApiKey, "SaladCloud API Key")
+	virtualKubeletCommand.Flags().StringVar(&inputs.OrganizationName, "sce-organization-name", inputs.OrganizationName, "SaladCloud Organization Name")
+	virtualKubeletCommand.Flags().StringVar(&inputs.ProjectName, "sce-project-name", inputs.ProjectName, "SaladCloud Project Name")
 
-	markFlagRequired("organizationName")
-	markFlagRequired("projectName")
+	markFlagRequired("sce-api-key")
+	markFlagRequired("sce-organization-name")
+	markFlagRequired("sce-project-name")
 }
 
 func markFlagRequired(flagName string) {


### PR DESCRIPTION
- Use the same format for option names everywhere, with '-' separating works
- Add 'sce-' prefix to Salad Cloud-specific options
