### PR TITLE
Add CA certificates to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21.3-alpine3.18 AS builder
+FROM golang:1.21.3-alpine3.18 AS build
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -12,8 +12,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/virtual-kubelet .
 
 FROM scratch AS final
 
+COPY --from=build /etc/ssl/certs /etc/ssl/certs
+COPY --from=build /etc/ssl/cert.pem /etc/ssl/cert.pem
 COPY LICENSE /LICENSE
 COPY NOTICE /NOTICE
-COPY --from=builder --chown=root:root /app/bin/virtual-kubelet /usr/bin/virtual-kubelet
+COPY --from=build --chown=root:root /app/bin/virtual-kubelet /usr/bin/virtual-kubelet
 
 ENTRYPOINT ["/usr/bin/virtual-kubelet"]


### PR DESCRIPTION
This adds CA certificates from the latest Alpine base image to the SaladCloud Virtual Kubelet image. This ensures the HTTP client is able to verify the SaladCloud API's TLS certificate.