### PR TITLE
Update _helpers.tpl - Fallback the "app.kubernetes.io/version" to "version", if "appVersion" is not specified in Chart.yml

### DIFF
--- a/charts/virtual-kubelet/templates/_helpers.tpl
+++ b/charts/virtual-kubelet/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Return the common labels used by components.
 app.kubernetes.io/component: kubelet
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ include "virtual-kubelet-saladcloud.name" . }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | default .Chart.Version }}
 helm.sh/chart: {{ include "virtual-kubelet-saladcloud.chart" . }}
 {{ include "virtual-kubelet-saladcloud.matchLabels" . }}
 {{- with .Values.additionalLabels -}}


### PR DESCRIPTION
This small patch enables fallback of the `app.kubernetes.io/version` to "version", if "appVersion" is not specified in Chart.yml.

This addresses the issue, when applying this repository's helm chart with templates, i.e. via ArgoCD: `rpc error: code = Unknown desc = Manifest generation error (cached): failed to set app instance tracking info on manifest: failed to set app instance label: failed to get labels from target object /v1, Kind=ServiceAccount default/salad-init-settings-deploy-virtual-kubelet-saladcloud-provider: .metadata.labels accessor error: contains non-string value in the map under key "app.kubernetes.io/version": <nil> is of the type <nil>, expected string` (i.e. #84)