### PR TITLE
Bring virtual-kubelet-saladcloud up to date with latest OpenAPI spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ go.work
 ## Custom Rules
 
 bin/
+.idea/
+.env

--- a/demo/web.yaml
+++ b/demo/web.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: web-demo
+  name: web
+  namespace: saladcloud-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-demo
+  template:
+    metadata:
+      annotations:
+        salad.com/country-codes: us
+        salad.com/networking-protocol: "http"
+        salad.com/networking-port: "80"
+        salad.com/networking-auth: "false"
+        salad.com/gpu-classes: "dec851b7-eba7-4457-a319-a01b611a810e"
+        salad.com/container-group-priority: "high"
+      labels:
+        app: web-demo
+    spec:
+      containers:
+        - image: httpd
+          name: web
+          resources:
+            requests:
+              cpu: "1"
+              memory: 8Gi
+            limits:
+              cpu: "1"
+              memory: 8Gi
+      nodeSelector:
+        kubernetes.io/role: agent
+        type: virtual-kubelet
+      os:
+        name: linux
+      restartPolicy: Always
+      tolerations:
+        - key: virtual-kubelet.io/provider
+          operator: Equal
+          value: saladcloud
+          effect: NoSchedule

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,15 @@ go 1.23.0
 toolchain go1.23.5
 
 require (
+	github.com/SaladTechnologies/salad-client v0.9.0-alpha.6
 	github.com/google/uuid v1.6.0
-	github.com/lucklypriyansh-2/salad-client v0.0.0-20231005114315-47f7f0403e30
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/virtual-kubelet/virtual-kubelet v1.11.1-0.20250117201309-5c534ffcd607
+	golang.org/x/text v0.21.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
@@ -92,7 +93,6 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
+github.com/SaladTechnologies/salad-client v0.9.0-alpha.6 h1:v92xS6b6iA0XcOCGimGyZowmGRcQAoMNApcIJnqpIFg=
+github.com/SaladTechnologies/salad-client v0.9.0-alpha.6/go.mod h1:yeYIXFVocy5Hd1hdKVz4J9cibiOI3uCz5GZIpZ8TJdk=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -137,8 +139,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/lucklypriyansh-2/salad-client v0.0.0-20231005114315-47f7f0403e30 h1:HrlYiLV6NAoalMkbfDnEjvO3FNJ9qcPTG+DZ47kktiA=
-github.com/lucklypriyansh-2/salad-client v0.0.0-20231005114315-47f7f0403e30/go.mod h1:aFjkAhEyFj9mGwJ+w4rE0tWMTjwE9OBNhl5/Q9dFNDE=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/internal/models/api_error.go
+++ b/internal/models/api_error.go
@@ -24,8 +24,16 @@ func NewSaladCloudError(err error, response *http.Response) error {
 	if response == nil {
 		return err
 	}
-	return &APIError{
-		StatusCode: response.StatusCode,
-		Message:    err.Error(),
+
+	if err == nil {
+		return &APIError{
+			StatusCode: response.StatusCode,
+			Message:    "",
+		}
+	} else {
+		return &APIError{
+			StatusCode: response.StatusCode,
+			Message:    err.Error(),
+		}
 	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
-	saladclient "github.com/lucklypriyansh-2/salad-client"
+	saladclient "github.com/SaladTechnologies/salad-client"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -19,26 +20,25 @@ func roundUpToNearest(value int64, list []int64) int64 {
 	return list[len(list)-1]
 }
 
-// GetPodResource returns the total CPU in rounded cores and memory rounded to gigabytes (GB) for the provided PodSpec.
+// GetPodResource returns the total CPU in rounded cores and memory rounded to gibibytes (GiB) for the provided PodSpec.
 func GetPodResource(podSpec corev1.PodSpec) (cpu int64, memory int64) {
 	allowedCPUValues := []int64{1, 2, 3, 4, 6, 8, 12, 16}
 
-	allowedMemoryValues := []int64{1024, 2048, 3072, 4 * 1024, 5 * 1024, 6 * 1024, 12 * 1024, 16 * 1024, 24 * 1024, 30 * 1024} // in GB
+	allowedMemoryValues := []int64{1024, 2048, 3072, 4 * 1024, 6 * 1024, 8 * 1024, 12 * 1024, 16 * 1024, 24 * 1024, 30 * 1024, 38 * 1024, 60 * 1024} // in GiB
 
 	for _, container := range podSpec.Containers {
 		// Convert milliCPU to cores and round to nearest value in the list
 		cpuValue := container.Resources.Requests.Cpu().MilliValue() / 1000
 		cpu += roundUpToNearest(cpuValue, allowedCPUValues)
 
-		// Convert bytes to gigabytes (MB) and ensure it's a multiple of 1 GB (1 GB = 1e9 bytes)
-		memValue := container.Resources.Requests.Memory().Value() / 1e6
+		// Convert bytes to gibibytes (MiB) and ensure it's a multiple of 1 Gi (1 Gi = 1024*1024 bytes)
+		memValue := container.Resources.Requests.Memory().Value() / (1024 * 1024)
 		memory += roundUpToNearest(memValue, allowedMemoryValues)
 	}
 	return
 }
 
 func GetPodName(nameSpace, containerGroup string, pod *corev1.Pod) string {
-
 	if nameSpace == "" {
 		nameSpace = pod.ObjectMeta.Namespace
 	}
@@ -52,13 +52,12 @@ func GetPodName(nameSpace, containerGroup string, pod *corev1.Pod) string {
 }
 
 func GetPodPhaseFromContainerGroupState(containerGroupState saladclient.ContainerGroupState) corev1.PodPhase {
-
 	switch containerGroupState.Status {
 	case saladclient.CONTAINERGROUPSTATUS_PENDING:
 		return corev1.PodPending
 	case saladclient.CONTAINERGROUPSTATUS_RUNNING:
 		{
-			if containerGroupState.InstanceStatusCount.RunningCount > 0 {
+			if containerGroupState.InstanceStatusCounts.RunningCount > 0 {
 				return corev1.PodRunning
 			}
 			return corev1.PodPending
@@ -79,9 +78,16 @@ func GetPodPhaseFromContainerGroupState(containerGroupState saladclient.Containe
 }
 
 func GetResponseBody(response *http.Response) (*saladclient.ProblemDetails, error) {
+	if response == nil {
+		return nil, fmt.Errorf("response was nil")
+	}
+
 	// Get response body for error info
 	body, _ := io.ReadAll(response.Body)
-	response.Body.Close()
+	closeErr := response.Body.Close()
+	if closeErr != nil {
+		return nil, closeErr
+	}
 	response.Body = io.NopCloser(bytes.NewBuffer(body))
 
 	// Get a ProblemDetails struct from the body

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -31,7 +31,7 @@ func GetPodResource(podSpec corev1.PodSpec) (cpu int64, memory int64) {
 		cpuValue := container.Resources.Requests.Cpu().MilliValue() / 1000
 		cpu += roundUpToNearest(cpuValue, allowedCPUValues)
 
-		// Convert bytes to gibibytes (MiB) and ensure it's a multiple of 1 Gi (1 Gi = 1024*1024 bytes)
+		// Convert bytes to gibibytes (GiB) and ensure it's a multiple of 1 GiB (1 GiB = 1024*1024 bytes)
 		memValue := container.Resources.Requests.Memory().Value() / (1024 * 1024)
 		memory += roundUpToNearest(memValue, allowedMemoryValues)
 	}


### PR DESCRIPTION
- **Updated Dependencies and Resource Management**: Upgraded `salad-client` to version `v0.9.0-alpha.6` and updated memory rounding logic to use gibibytes (GiB) instead of gigabytes (GB) for improved accuracy in resource management.

- **Authentication and Secrets Handling**: Modified `SaladCloudProvider` to use base64 encoding for registry authentication and added a `SecretLister` to manage secrets effectively.

- **Demo and Configuration Updates**:
  - Renamed the `web-demo` deployment and updated the Ubuntu demo to use a new networking protocol and container image.
  - The `web-demo` allows for quickly testing if a Kubernetes Rollout is working properly by swapping between `httpd` and `nginx`.
  - Added `fmt` import and improved pod status reporting with detailed logging for probes and phase transitions.

- **Refactoring and Code Improvements**:
  - Refactored `provider.go` by removing unnecessary `time.Sleep` calls and updating pod creation phases.
  - Container group is configured to auto-start thus simplifying the `CreatePod` logic a bit.

- **New Features and Enhancements**:
  - Added support for `imagePullSecrets` and priority via Pod spec.
  - Enhanced `SaladCloudProvider` to handle Probe types (readiness, liveness, and startup) and introduced methods to convert Kubernetes Probes to SaladClient Probes.
  - Added a `web` recipe for quicker testing and updated allowed memory values to include 38GB (60GB in GB).

<!--

Thanks for opening a pull request! Here are some tips:

- Review the contributing guidelines and code of conduct.
- If the work is incomplete, please open the pull request as a "Draft".

-->
