### PR TITLE
Publish Docker image for main branch commits and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
     branches:
       - main
@@ -11,9 +13,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Collect Git metadata
+        id: git
+        run: |
+          echo "commit_date=$(git log -1 --format=%cd --date=format:"%Y%m%d")" >> "$GITHUB_OUTPUT"
+          echo "commit_timestamp=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
       - name: Setup Docker BuildKit
         uses: docker/setup-buildx-action@v3
       - name: Collect metadata
@@ -29,14 +38,27 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha,format=long
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build container image
         uses: docker/build-push-action@v6
         with:
           context: .
+          build-args: |
+            VERSION_FLAGS=-ldflags=-X "main.buildVersion=${{ github.sha }}" -X "main.buildTime=${{ steps.git.outputs.commit_date }}"
           file: ./docker/Dockerfile
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64
           pull: true
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.metadata.outputs.tags }}
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.git.outputs.commit_timestamp }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23.6-alpine3.21 AS build
+FROM golang:1.24.0-alpine3.21 AS build
 WORKDIR /app
 ARG VERSION_FLAGS=-ldflags=
 
@@ -9,7 +9,7 @@ RUN go mod download && \
     go mod verify
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build "${VERSION_FLAGS}" -o /app/bin/virtual-kubelet ./cmd/virtual-kubelet/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build "${VERSION_FLAGS}" -o ./bin/virtual-kubelet ./cmd/virtual-kubelet/main.go
 
 FROM scratch AS final
 


### PR DESCRIPTION
Expands the CI workflow to publish the Docker image when triggered by a main branch commit or a tag.