### PR TITLE
Fix Docker image URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            saladtechnologies/virtual-kubelet-saladcloud
+            ghcr.io/saladtechnologies/virtual-kubelet-saladcloud
           labels: |
             org.opencontainers.image.title=SaladCloud Virtual Kubelet Provider
             org.opencontainers.image.description=Enables running Kubernetes pods remotely on SaladCloud


### PR DESCRIPTION
This fixes the Docker image URL. Totally missed the `ghcr.io` domain. 🤦‍♂️