### PR TITLE
Do not set a default country code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.10.0
 	github.com/virtual-kubelet/virtual-kubelet v1.11.1-0.20250117201309-5c534ffcd607
 	golang.org/x/text v0.23.0
 	k8s.io/api v0.32.2
@@ -68,6 +69,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.21.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	saladclient "github.com/SaladTechnologies/salad-client"
+	// "github.com/SaladTechnologies/virtual-kubelet-saladcloud/internal/provider"
+	"github.com/SaladTechnologies/virtual-kubelet-saladcloud/internal/models"
+	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
+)
+
+// from cmd/virtual-kubelet-saladcloud/main.go
+func defaultInputs() models.InputVars {
+	home, err := homedir.Dir()
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if err == nil && home != "" {
+		kubeConfig = filepath.Join(home, ".kube", "config")
+	}
+
+	return models.InputVars{
+		NodeName:         "saladcloud-node",
+		KubeConfig:       kubeConfig,
+		LogLevel:         "info",
+		OrganizationName: "",
+		TaintKey:         "virtual-kubelet.io/provider",
+		TaintEffect:      "NoSchedule",
+		TaintValue:       "saladcloud",
+		ProjectName:      "",
+		ApiKey:           "",
+	}
+}
+
+func newProvider() (*SaladCloudProvider, error) {
+	ctx := context.Background()
+	inputs := defaultInputs()
+	pc := nodeutil.ProviderConfig{}
+	return NewSaladCloudProvider(ctx, inputs, pc)
+}
+
+func Test_getCountryCodes(t *testing.T) {
+	p, _ := newProvider()
+
+	// No CC in Annotations
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+	expectCC := &[]saladclient.CountryCode{}
+
+	cc, err := p.getCountryCodes(pod)
+	assert.Nil(t, err)
+	assert.NotNil(t, cc)
+	assert.Equal(t, *expectCC, cc)
+
+	// One CC in Annotations
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"salad.com/country-codes": "mx",
+			},
+		},
+	}
+	expectCC = &[]saladclient.CountryCode{
+		saladclient.CountryCode("mx"),
+	}
+
+	cc, err = p.getCountryCodes(pod)
+	assert.Nil(t, err)
+	assert.NotNil(t, cc)
+	assert.Equal(t, *expectCC, cc)
+
+	// Multiple CC in Annotations
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"salad.com/country-codes": "mx,ca",
+			},
+		},
+	}
+	expectCC = &[]saladclient.CountryCode{
+		saladclient.CountryCode("mx"),
+		saladclient.CountryCode("ca"),
+	}
+
+	cc, err = p.getCountryCodes(pod)
+	assert.Nil(t, err)
+	assert.NotNil(t, cc)
+	assert.Equal(t, *expectCC, cc)
+
+	// One upper-case CC in Annotations
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"salad.com/country-codes": "MX",
+			},
+		},
+	}
+	expectCC = &[]saladclient.CountryCode{
+		saladclient.CountryCode("mx"),
+	}
+
+	cc, err = p.getCountryCodes(pod)
+	assert.Nil(t, err)
+	assert.NotNil(t, cc)
+	assert.Equal(t, *expectCC, cc)
+
+	// Multiple mixed case CC in Annotations
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"salad.com/country-codes": "MX,ca",
+			},
+		},
+	}
+	expectCC = &[]saladclient.CountryCode{
+		saladclient.CountryCode("mx"),
+		saladclient.CountryCode("ca"),
+	}
+
+	cc, err = p.getCountryCodes(pod)
+	assert.Nil(t, err)
+	assert.NotNil(t, cc)
+	assert.Equal(t, *expectCC, cc)
+
+	// Invalid CC in Annotations
+	pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"salad.com/country-codes": "XX",
+			},
+		},
+	}
+	expectCC = &[]saladclient.CountryCode{}
+
+	cc, err = p.getCountryCodes(pod)
+	assert.NotNil(t, err)
+	assert.NotNil(t, cc)
+	assert.Equal(t, *expectCC, cc)
+
+}


### PR DESCRIPTION
Fixes https://github.com/SaladTechnologies/virtual-kubelet-saladcloud/issues/126

"US" was being used as a default country code if one was not present in the pod annotations. Remove these defauts and allow CC not present to be valid.

Also force input CC values to lower case as the salad-client tests only consider lower case values.

Add tests for SaladCloudProvider.getCountryCode()